### PR TITLE
Add summary and description to gemspec.

### DIFF
--- a/capistrano-runit-rake.gemspec
+++ b/capistrano-runit-rake.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = '0.2.0'
   spec.authors       = ["Alexander Simonov"]
   spec.email         = ["alex@simonov.me"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Capistrano3 tasks to manage rake tasks via runit supervisor.}
+  spec.description   = %q{Capistrano3 tasks to manage rake tasks via runit supervisor.}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
This should get rid of error messages like: The gemspec at ... is not valid. The validation error was '"FIXME" or "TODO" is not a description'.
